### PR TITLE
Add blueprints

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-presents/files/app/presentation.js
+++ b/blueprints/ember-presents/files/app/presentation.js
@@ -1,0 +1,1 @@
+export default [];

--- a/blueprints/ember-presents/index.js
+++ b/blueprints/ember-presents/index.js
@@ -1,0 +1,8 @@
+/*jshint node:true*/
+
+'use strict';
+
+module.exports = {
+  description: 'Generates default "presentation.js" file',
+  normalizeEntityName: function() {}
+};

--- a/blueprints/slide/files/app/templates/slides/__name__.hbs
+++ b/blueprints/slide/files/app/templates/slides/__name__.hbs
@@ -1,0 +1,1 @@
+<h1><%= dasherizedModuleName %></h1>

--- a/blueprints/slide/index.js
+++ b/blueprints/slide/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  description: 'Generates a new presentation slide',
+
+  // locals: function(options) {
+  //   // Return custom template variables here.
+  //   return {
+  //     foo: options.entity.options.foo
+  //   };
+  // }
+
+  afterInstall: function(options) {
+    console.log(options);
+    // var file = 'app/presentation.js';
+    // var text = "";
+    // var afterText = "import resolver from './helpers/resolver';" + EOL;
+
+    // return this.insertIntoFile(file, text, { after: afterText});
+  }
+};

--- a/blueprints/slide/index.js
+++ b/blueprints/slide/index.js
@@ -1,19 +1,9 @@
 module.exports = {
   description: 'Generates a new presentation slide',
 
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // }
+  normalizeEntityName: function() {},
 
   afterInstall: function(options) {
-    console.log(options);
-    // var file = 'app/presentation.js';
-    // var text = "";
-    // var afterText = "import resolver from './helpers/resolver';" + EOL;
-
-    // return this.insertIntoFile(file, text, { after: afterText});
+    // TODO: Generate slide url in `presentations.js`
   }
 };

--- a/blueprints/slide/index.js
+++ b/blueprints/slide/index.js
@@ -1,8 +1,6 @@
 module.exports = {
   description: 'Generates a new presentation slide',
 
-  normalizeEntityName: function() {},
-
   afterInstall: function(options) {
     // TODO: Generate slide url in `presentations.js`
   }


### PR DESCRIPTION
This still doesn't add the slide to the `presentations.js` array. 

Adds two blueprints:
- `ember-presents` which is ran when someone does `ember install ember-presents`. This will create the `presentations.js` file in the `app` root. 
- `slide` which will create the template file for you. Run by doing `ember g slide my-slide-name`
