### PR TITLE
Don't move forward if at the beginning or end

### DIFF
--- a/app/routes/slide.js
+++ b/app/routes/slide.js
@@ -6,6 +6,7 @@ let $ = Ember.$;
 export default Ember.Route.extend({
   model(params) {
     var index = presentation.indexOf(params.id);
+
     if (index < 0) {
       throw new Error(`unknown slide: ${params.id}`);
     }
@@ -17,6 +18,11 @@ export default Ember.Route.extend({
 
   move(distance) {
     let currentIndex = this.get('controller.model.index');
+
+    if(!presentation[currentIndex + distance]) {
+      return;
+    }
+
     this.transitionTo('slide', presentation[currentIndex + distance]);
   },
 

--- a/tests/acceptance/presentation-test.js
+++ b/tests/acceptance/presentation-test.js
@@ -29,6 +29,7 @@ describe('Acceptance: Presentation', function() {
       });
       it("remains on the first slide", function() {
         expect($('.spec-the-first-slide-title')).to.have.text('Ember Presents!');
+        expect(currentURL()).to.equal('/ember-presents');
       });
     });
     describe("hitting the right arrow", function() {
@@ -36,9 +37,27 @@ describe('Acceptance: Presentation', function() {
         keyEvent(window, 'keydown', 39);
         keyEvent(window, 'keyup', 39);
       });
+
       it("transitions to the seconds slide", function() {
         expect($('.spec-the-second-slide-title')).to.have.text('Is This a Good Idea?');
       });
+
+    });
+
+    describe("loading the last slide and hitting the right arrow", function() {
+      beforeEach(function() {
+        return visit('that-means-ember');
+      });
+
+      beforeEach(function() {
+        keyEvent(window, 'keydown', 39);
+        keyEvent(window, 'keyup', 39);
+      });
+
+      it("doesn't advance slides", function() {
+        expect(currentURL()).to.equal('that-means-ember');
+      });
+
     });
 
   });


### PR DESCRIPTION
When arrowing forward or back at the beginning or end of the slide deck you'd get an `undefined` route. This eliminates that
